### PR TITLE
feat/configurable-panel-name

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ const AdminUsers = lazy(() => import('./pages/[admin]/Users'));
 const AdminCargo = lazy(() => import('./pages/[admin]/Cargo'));
 const AdminRegions = lazy(() => import('./pages/[admin]/Regions'));
 const AdminAPIKeys = lazy(() => import('./pages/[admin]/APIKeys'));
+const AdminSettings = lazy(() => import('./pages/[admin]/Settings')); // Import the new Settings page
 
 // Servers
 const ServerConsole = lazy(() => import('./pages/[server]/Console'));
@@ -296,6 +297,7 @@ function App() {
                         <Route path="/admin/cargo" element={<AdminCargo />} />
                         <Route path="/admin/regions" element={<AdminRegions />} />
                         <Route path="/admin/api-keys" element={<AdminAPIKeys />} />
+                        <Route path="/admin/settings" element={<AdminSettings />} /> {/* Add the new route */}
 
                         {/* Server routes */}
                         <Route

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -353,6 +353,14 @@ function Sidebar() {
               />
 
               <NavItem 
+                to="/admin/settings" 
+                icon={Cog6ToothIcon} 
+                label="Settings" 
+                isActive={location.pathname === '/admin/settings'}
+                setRef={setTabRef}
+              />
+
+              <NavItem 
                 to="/admin/api-keys" 
                 icon={KeyIcon} 
                 label="API Keys" 

--- a/frontend/src/contexts/SystemContext.tsx
+++ b/frontend/src/contexts/SystemContext.tsx
@@ -10,6 +10,7 @@ interface SystemContextType {
   systemInfo: SystemInfo | null;
   loading: boolean;
   error: string | null;
+  updatePanelName: (newName: string) => void; // Added function to update panel name
 }
 
 const defaultSystemInfo: SystemInfo = {
@@ -21,7 +22,8 @@ const defaultSystemInfo: SystemInfo = {
 const SystemContext = createContext<SystemContextType>({
   systemInfo: defaultSystemInfo,
   loading: true,
-  error: null
+  error: null,
+  updatePanelName: () => console.warn('updatePanelName function not yet implemented') // Default empty implementation
 });
 
 export const useSystem = () => useContext(SystemContext);
@@ -35,10 +37,10 @@ export const SystemProvider: React.FC<SystemProviderProps> = ({ children }) => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchSystemInfo = async () => {
-      try {
-        const response = await fetch('/api/system');
+  const fetchSystemInfo = async () => { // Extracted to a function
+    setLoading(true);
+    try {
+      const response = await fetch('/api/system');
         
         if (!response.ok) {
           throw new Error(`Failed to fetch system info: ${response.status}`);
@@ -46,19 +48,34 @@ export const SystemProvider: React.FC<SystemProviderProps> = ({ children }) => {
         
         const data = await response.json();
         setSystemInfo(data);
+        setError(null); // Clear previous errors on success
       } catch (err) {
         console.error('Error fetching system info:', err);
         setError(err instanceof Error ? err.message : 'Unknown error');
+        // Keep stale data if fetch fails, or set to default/null
       } finally {
         setLoading(false);
       }
     };
 
+  useEffect(() => {
     fetchSystemInfo();
   }, []);
 
+  const updatePanelName = (newName: string) => {
+    setSystemInfo(prevInfo => {
+      if (prevInfo) {
+        return { ...prevInfo, name: newName };
+      }
+      // If prevInfo is null, we might want to initialize it or handle this case differently
+      // For now, let's assume prevInfo is unlikely to be null after initial load.
+      // Or, fetchSystemInfo() could be called again here to ensure full consistency.
+      return { ...defaultSystemInfo, name: newName }; 
+    });
+  };
+
   return (
-    <SystemContext.Provider value={{ systemInfo, loading, error }}>
+    <SystemContext.Provider value={{ systemInfo, loading, error, updatePanelName }}>
       {children}
     </SystemContext.Provider>
   );

--- a/frontend/src/pages/[admin]/Settings.tsx
+++ b/frontend/src/pages/[admin]/Settings.tsx
@@ -1,0 +1,156 @@
+import React, { useState, useEffect } from 'react';
+import { useSystem } from '../../contexts/SystemContext'; // Adjust path as necessary
+import { ArrowLeftIcon } from 'lucide-react'; // Or any other icon library you're using
+
+const AdminSettingsPage: React.FC = () => {
+  const { systemInfo, loading: systemLoading, error: systemError, updatePanelName } = useSystem(); // Added updatePanelName
+  const [panelName, setPanelName] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (systemInfo && systemInfo.name) {
+      setPanelName(systemInfo.name);
+    }
+  }, [systemInfo]);
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setFormError(null);
+    setSuccessMessage(null);
+
+    const token = localStorage.getItem('token');
+    if (!token) {
+      setFormError('Authentication token not found. Please log in again.');
+      setIsLoading(false);
+      return;
+    }
+
+    if (!panelName.trim()) {
+      setFormError('Panel name cannot be empty.');
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const response = await fetch('/api/system/settings', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify({ panel_name: panelName }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || `Error: ${response.status}`);
+      }
+
+      // Success
+      updatePanelName(panelName); // Update context
+      setSuccessMessage('Panel name updated successfully!');
+      // Optionally, refetch systemInfo from context if it was more complex
+      // Or if the backend returns the full updated object, use that.
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred.';
+      setFormError(`Failed to update panel name: ${errorMessage}`);
+      // Restore original name on error if desired, or let user correct
+      // if (systemInfo && systemInfo.name) {
+      //   setPanelName(systemInfo.name);
+      // }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (systemLoading) {
+    return (
+      <div className="p-6 flex items-center justify-center h-64">
+        <p className="text-gray-500 text-sm">Loading settings...</p>
+      </div>
+    );
+  }
+
+  if (systemError) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md">
+          Error loading system information: {systemError}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="p-6">
+        <div className="space-y-6">
+          <div className="flex items-center space-x-3">
+            {/* Optional: Back button if this page is part of a nested admin structure */}
+            {/* <button
+              onClick={() => window.history.back()}
+              className="p-2 rounded-md hover:bg-gray-100"
+            >
+              <ArrowLeftIcon className="w-5 h-5 text-gray-600" />
+            </button> */}
+            <div>
+              <h1 className="text-lg font-semibold text-gray-900">System Settings</h1>
+              <p className="text-xs text-gray-500 mt-1">
+                Manage system-wide settings for your panel.
+              </p>
+            </div>
+          </div>
+
+          {formError && (
+            <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-md text-xs">
+              {formError}
+            </div>
+          )}
+          {successMessage && (
+            <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-md text-xs">
+              {successMessage}
+            </div>
+          )}
+
+          <div className="bg-white border border-gray-200 rounded-md shadow-xs">
+            <form onSubmit={handleSave}>
+              <div className="p-6 space-y-4">
+                <div className="space-y-1">
+                  <label htmlFor="panelName" className="block text-xs font-medium text-gray-700">
+                    Panel Name
+                  </label>
+                  <input
+                    type="text"
+                    id="panelName"
+                    value={panelName}
+                    onChange={(e) => setPanelName(e.target.value)}
+                    className="block w-full max-w-md px-3 py-2 text-xs border border-gray-200 rounded-md focus:outline-none focus:border-gray-400"
+                    placeholder="Your Panel Name"
+                    disabled={isLoading}
+                  />
+                  <p className="text-xs text-gray-500 mt-1">
+                    This name will be displayed throughout the panel.
+                  </p>
+                </div>
+              </div>
+              <div className="px-6 py-3 bg-gray-50 border-t border-gray-200 flex justify-end">
+                <button
+                  type="submit"
+                  className="px-4 py-2 text-xs font-medium text-white bg-gray-900 rounded-md hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900 disabled:opacity-50"
+                  disabled={isLoading || !panelName.trim() || (systemInfo && panelName === systemInfo.name)}
+                >
+                  {isLoading ? 'Saving...' : 'Save Settings'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminSettingsPage;

--- a/server/migrations/init_schema.ts
+++ b/server/migrations/init_schema.ts
@@ -155,6 +155,33 @@ export function up(db: Database) {
       FOREIGN KEY(userId) REFERENCES users(id) ON DELETE CASCADE
     );
 
+    -- System Settings Table
+    CREATE TABLE IF NOT EXISTS system_settings (
+      id TEXT PRIMARY KEY,
+      key TEXT UNIQUE NOT NULL,
+      value TEXT NOT NULL,
+      createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+      updatedAt TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    -- Seed default panel name
+    INSERT OR IGNORE INTO system_settings (id, key, value) 
+    VALUES (
+      '${crypto.randomUUID()}', 
+      'panel_name', 
+      'Argon'
+    );
+
+    -- Trigger for system_settings updatedAt
+    CREATE TRIGGER IF NOT EXISTS update_system_settings_updatedAt
+    AFTER UPDATE ON system_settings
+    FOR EACH ROW
+    BEGIN
+      UPDATE system_settings
+      SET updatedAt = datetime('now')
+      WHERE id = OLD.id;
+    END;
+
     CREATE INDEX IF NOT EXISTS idx_api_keys_user_id ON api_keys(userId);
     CREATE INDEX IF NOT EXISTS idx_api_keys_key ON api_keys(key);
     CREATE INDEX IF NOT EXISTS idx_nodes_region_id ON nodes(regionId);
@@ -187,5 +214,7 @@ export function down(db: Database) {
     DROP TABLE IF EXISTS units;
     DROP TABLE IF EXISTS nodes;
     DROP TABLE IF EXISTS users;
+    DROP TABLE IF EXISTS system_settings; -- Added for down migration
+    DROP TRIGGER IF EXISTS update_system_settings_updatedAt; -- Added for down migration
   `);
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -26,11 +26,32 @@ app.use(express.json());
 const routersDir = join(__dirname, 'src', 'routers');
 app.use(loadRouters(routersDir));
 
-app.get('/api/system', (req, res) => {
-  res.json({
-    name: process.env.PANEL_NAME || 'Argon',
-    version: '1.0.0'
-  });
+// Import db instance
+import { db } from './db';
+
+app.get('/api/system', async (req, res) => { // Made async
+  try {
+    let panelName = 'Argon'; // Default name
+    const setting = db.db.query(
+      `SELECT value FROM system_settings WHERE key = 'panel_name'`
+    ).get() as { value: string } | undefined;
+
+    if (setting && setting.value) {
+      panelName = setting.value;
+    }
+
+    res.json({
+      name: panelName,
+      version: '1.0.0' // Assuming version remains static or managed elsewhere
+    });
+  } catch (error) {
+    console.error('Error fetching panel name:', error);
+    // Fallback to default name in case of error
+    res.json({
+      name: 'Argon',
+      version: '1.0.0'
+    });
+  }
 });
 
 const frontendPath = resolve(__dirname, '../frontend/dist');

--- a/server/src/routers/system.ts
+++ b/server/src/routers/system.ts
@@ -1,0 +1,49 @@
+import { Router, Request, Response } from 'express';
+import { db } from '../db';
+import { authMiddleware, checkPermission } from '../middleware/auth';
+import { Permissions } from '../permissions'; // Changed import from Permission to Permissions
+import { z } from 'zod';
+import { validateRequestBody } from '../middleware/validation';
+
+const router = Router();
+
+const updateSettingsSchema = z.object({
+  panel_name: z.string().min(1, 'Panel name cannot be empty'),
+});
+
+router.put(
+  '/system/settings',
+  authMiddleware,
+  checkPermission(Permissions.ADMIN), // Changed to Permissions.ADMIN
+  validateRequestBody(updateSettingsSchema),
+  async (req: Request, res: Response) => {
+    const { panel_name } = req.body;
+
+    try {
+      // Check if the panel_name key exists
+      const existingSetting = db.db.query(
+        `SELECT id FROM system_settings WHERE key = 'panel_name'`
+      ).get() as { id: string } | undefined;
+
+      if (existingSetting) {
+        // Update existing setting
+        db.db.prepare(
+          `UPDATE system_settings SET value = ?, updatedAt = datetime('now') WHERE key = 'panel_name'`
+        ).run(panel_name);
+      } else {
+        // Insert new setting if it doesn't exist (should have been seeded by migration)
+        db.db.prepare(
+          `INSERT INTO system_settings (id, key, value, createdAt, updatedAt) 
+           VALUES (?, 'panel_name', ?, datetime('now'), datetime('now'))`
+        ).run(crypto.randomUUID(), panel_name);
+      }
+      
+      res.status(200).json({ message: 'Panel name updated successfully' });
+    } catch (error) {
+      console.error('Error updating panel name:', error);
+      res.status(500).json({ error: 'Failed to update panel name' });
+    }
+  }
+);
+
+export default router;


### PR DESCRIPTION
refactor: Update panel name configuration based on feedback

This commit refactors the previously implemented panel name configuration feature according to your feedback.

Changes:
- Merged the database migration for the `system_settings` table into the initial schema migration (`server/migrations/init_schema.ts`). The separate migration file was removed. The `down()` function in `init_schema.ts` has also been updated to include dropping the `system_settings` table and its associated trigger.
- Changed the authorization for the `PUT /api/system/settings` endpoint to use the existing general `Permissions.ADMIN` ('admin') permission instead of a new, specific permission. The `Permission.SYSTEM_SETTINGS_MANAGE` has been removed from the system.

The functionality for making the panel name configurable via the UI remains the same.

Note: The database migration (now part of `init_schema.ts`) still needs to be run if it hasn't been applied since these changes. The command is likely `argon bolt migrate --run` or similar.